### PR TITLE
Objects can be compared with `==`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-None.
+### Added
+
+- Objects can be compared with `==`.
 
 ## [1.0.5] - 2023-07-10
 

--- a/lib/virtual_assembly/semantizer/semantic_object.rb
+++ b/lib/virtual_assembly/semantizer/semantic_object.rb
@@ -141,6 +141,10 @@ module VirtualAssembly
         serializer.process(self)
       end
 
+      def ==(other)
+        semanticProperties == other.semanticProperties
+      end
+
       protected
 
       # If the semantic property already exist in this object, this

--- a/lib/virtual_assembly/semantizer/semantic_property.rb
+++ b/lib/virtual_assembly/semantizer/semantic_property.rb
@@ -72,6 +72,10 @@ module VirtualAssembly
       def value=(new_value)
         @valueSetter.call(new_value)
       end
+
+      def ==(other)
+        name == other.name && value == other.value
+      end
     end
   end
 end

--- a/spec/lib/virtual_assembly/semantizer/semantic_object_spec.rb
+++ b/spec/lib/virtual_assembly/semantizer/semantic_object_spec.rb
@@ -6,6 +6,11 @@ describe VirtualAssembly::Semantizer::SemanticObject do
       include VirtualAssembly::Semantizer::SemanticObject
     end.new
   end
+  let(:other_clazz) do
+    Class.new(Object) do
+      include VirtualAssembly::Semantizer::SemanticObject
+    end
+  end
 
   it 'has a semantic id' do
     expect { object.semanticId = 'five' }
@@ -26,5 +31,21 @@ describe VirtualAssembly::Semantizer::SemanticObject do
 
     expect { object.semanticProperty('@id').value = 'six' }
       .to change { object.semanticPropertyValue('@id') }.from('five').to('six')
+  end
+
+  it 'can be compared' do
+    expect(object).to eq object.clone
+    expect(object).to eq other_clazz.new
+
+    expect(object).to_not eq other_clazz.new("id5")
+    expect(object).to_not eq other_clazz.new(nil, "typeA")
+
+    object.semanticId = "id5"
+    object.semanticType = "typeA"
+
+    expect(object).to eq other_clazz.new("id5", "typeA")
+
+    expect(object).to_not eq other_clazz.new("id5")
+    expect(object).to_not eq other_clazz.new(nil, "typeA")
   end
 end

--- a/spec/lib/virtual_assembly/semantizer/semantic_property_spec.rb
+++ b/spec/lib/virtual_assembly/semantizer/semantic_property_spec.rb
@@ -21,4 +21,15 @@ describe VirtualAssembly::Semantizer::SemanticProperty do
       .to change { property.value }
       .from("rain").to("sunshine")
   end
+
+  it 'can be compared' do
+    green = described_class.new("colour") { "green" }
+    green_colour = described_class.new("colour") { "green" }
+    green_grass = described_class.new("ground_type") { "green" }
+    purple = described_class.new("colour") { "purple" }
+
+    expect(green).to eq green_colour
+    expect(green).to_not eq green_grass
+    expect(green).to_not eq purple
+  end
 end


### PR DESCRIPTION
This will be handy in several scenarios, for example:

- specs to verify `tomato == import(export(tomato))`
- avoid write operations when an update call doesn't change anything